### PR TITLE
Fix DumpFile needing excessive memory

### DIFF
--- a/Classes/Driver/DropboxDriver.php
+++ b/Classes/Driver/DropboxDriver.php
@@ -15,6 +15,7 @@ namespace SFroemken\FalDropbox\Driver;
  */
 use Kunnu\Dropbox\Dropbox;
 use Kunnu\Dropbox\DropboxApp;
+use Kunnu\Dropbox\DropboxFile;
 use Kunnu\Dropbox\Models\FileMetadata;
 use Kunnu\Dropbox\Models\FolderMetadata;
 use TYPO3\CMS\Core\Cache\CacheManager;
@@ -686,7 +687,10 @@ class DropboxDriver extends AbstractDriver
     public function dumpFileContents($identifier)
     {
         $handle = fopen('php://output', 'w');
-        fputs($handle, $this->dropbox->download($identifier)->getContents());
+        $this->dropbox->download(
+            $identifier,
+            DropboxFile::createByStream('php://output', $handle, DropboxFile::MODE_WRITE)
+        );
         fclose($handle);
     }
     

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=5.5.0 <8.0",
     "typo3/cms": ">=7.6.0,<9.0",
-    "kunalvarma05/dropbox-php-sdk": ">=0.2.0"
+    "kunalvarma05/dropbox-php-sdk": ">=0.2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8.0"

--- a/vendor/kunalvarma05/dropbox-php-sdk/.gitignore
+++ b/vendor/kunalvarma05/dropbox-php-sdk/.gitignore
@@ -2,3 +2,5 @@ index.php
 .phpintel/
 /vendor/
 composer.lock
+/.idea
+.php_cs.cache

--- a/vendor/kunalvarma05/dropbox-php-sdk/README.md
+++ b/vendor/kunalvarma05/dropbox-php-sdk/README.md
@@ -1,5 +1,13 @@
 Dropbox SDK v2 for PHP
 ======================================================
+[![Latest Stable Version](https://poser.pugx.org/kunalvarma05/dropbox-php-sdk/v/stable?format=flat-square)](https://packagist.org/packages/kunalvarma05/dropbox-php-sdk)
+[![Build Status](https://img.shields.io/travis/kunalvarma05/dropbox-php-sdk.svg?style=flat-square)](https://travis-ci.org/kunalvarma05/dropbox-php-sdk)
+[![Quality Score](https://img.shields.io/scrutinizer/g/kunalvarma05/dropbox-php-sdk.svg?style=flat-square)](https://scrutinizer-ci.com/g/kunalvarma05/dropbox-php-sdk)
+[![Total Downloads](https://img.shields.io/packagist/dt/kunalvarma05/dropbox-php-sdk.svg?style=flat-square)](https://packagist.org/packages/kunalvarma05/dropbox-php-sdk)
+[![StyleCI](https://styleci.io/repos/61913555/shield?branch=master)](https://styleci.io/repos/61913555)
+[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://packagist.org/packages/kunalvarma05/dropbox-php-sdk)
+
+
 An unofficial PHP SDK to work with the [Dropbox API v2](https://www.dropbox.com/developers/documentation/http/documentation).
 
 <img src="https://cloud.githubusercontent.com/assets/893057/13731118/b7cf0e4e-e987-11e5-942f-13c53d65da35.png">

--- a/vendor/kunalvarma05/dropbox-php-sdk/composer.json
+++ b/vendor/kunalvarma05/dropbox-php-sdk/composer.json
@@ -17,5 +17,8 @@
         "psr-4": {
             "Kunnu\\Dropbox\\": "src/Dropbox"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.0"
     }
 }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Authentication/OAuth2Client.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Authentication/OAuth2Client.php
@@ -38,6 +38,13 @@ class OAuth2Client
     protected $client;
 
     /**
+     * Random String Generator
+     *
+     * @var \Kunnu\Dropbox\Security\RandomStringGeneratorInterface
+     */
+    protected $randStrGenerator;
+
+    /**
      * Create a new DropboxApp instance
      *
      * @param \Kunnu\Dropbox\DropboxApp $app
@@ -108,7 +115,7 @@ class OAuth2Client
             'state' => $state,
             ], $params);
 
-        if(!is_null($redirectUri)) {
+        if (!is_null($redirectUri)) {
             $params['redirect_uri'] = $redirectUri;
         }
 
@@ -126,9 +133,6 @@ class OAuth2Client
      */
     public function getAccessToken($code, $redirectUri = null, $grant_type = 'authorization_code')
     {
-        //Access Token (Should most probably be null)
-        $accessToken = $this->getApp()->getAccessToken();
-
         //Request Params
         $params = [
         'code' => $code,
@@ -176,6 +180,6 @@ class OAuth2Client
         $request->setParams(['validateResponse' => false]);
 
         //Revoke Access Token
-        $response = $this->getClient()->sendRequest($request);
+        $this->getClient()->sendRequest($request);
     }
 }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxClient.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxClient.php
@@ -153,7 +153,7 @@ class DropboxClient
 
         $options = [];
         if ($response instanceof DropboxResponseToFile) {
-            $options['sink'] = $response->getFilePath();
+            $options['sink'] = $response->getSteamOrFilePath();
         }
 
         //Send the Request to the Server through the HTTP Client
@@ -175,7 +175,7 @@ class DropboxClient
     /**
      * Prepare a Request before being sent to the HTTP Client
      *
-     * @param  DropboxResponse $request
+     * @param  \Kunnu\Dropbox\DropboxRequest $request
      *
      * @return array [Request URL, Request Headers, Request Body]
      */

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxFile.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxFile.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Kunnu\Dropbox;
 
 use Kunnu\Dropbox\Exceptions\DropboxClientException;
@@ -9,6 +10,7 @@ use Kunnu\Dropbox\Exceptions\DropboxClientException;
 class DropboxFile
 {
     const MODE_READ = 'r';
+
     const MODE_WRITE = 'w';
 
     /**
@@ -49,6 +51,13 @@ class DropboxFile
     protected $mode;
 
     /**
+     * Flag to see if we created an instance using a stream
+     *
+     * @var bool
+     */
+    private $isStream = false;
+
+    /**
      * Create a new DropboxFile instance
      *
      * @param string $filePath Path of the file to upload
@@ -61,11 +70,69 @@ class DropboxFile
     }
 
     /**
+     * Create a new DropboxFile instance using a file stream
+     *
+     * @param        $fileName
+     * @param        $resource
+     * @param string $mode
+     *
+     * @return DropboxFile
+     * @throws DropboxClientException
+     */
+    public static function createByStream($fileName, $resource, $mode = self::MODE_READ)
+    {
+        // create a new stream and set it to the dropbox file
+        $stream = \GuzzleHttp\Psr7\stream_for($resource);
+        if (!$stream) {
+            throw new DropboxClientException('Failed to create DropboxFile instance. Unable to open the given resource.');
+        }
+
+        // Try to get the file path from the stream (we'll need this for uploading bigger files)
+        $filePath = $stream->getMetadata('uri');
+        if (!is_null($filePath)) {
+            $fileName = $filePath;
+        }
+
+        $dropboxFile = new self($fileName, $mode);
+        $dropboxFile->setStream($stream);
+
+        return $dropboxFile;
+    }
+
+    /**
+     * Create a new DropboxFile instance using a file path
+     *
+     * This behaves the same as the constructor but was added in order to
+     * match the syntax of the static createByStream function
+     *
+     * @see DropboxFile::createByStream()
+     *
+     * @param $filePath
+     * @param $mode
+     *
+     * @return DropboxFile
+     */
+    public static function createByPath($filePath, $mode)
+    {
+        return new self($filePath, $mode);
+    }
+
+    /**
      * Closes the stream when destructed.
      */
     public function __destruct()
     {
         $this->close();
+    }
+
+    /**
+     * Close the file stream
+     */
+    public function close()
+    {
+        if ($this->stream) {
+            $this->stream->close();
+        }
     }
 
     /**
@@ -88,54 +155,6 @@ class DropboxFile
     public function setMaxLength($maxLength)
     {
         $this->maxLength = $maxLength;
-    }
-
-    /**
-     * Opens the File Stream
-     *
-     * @throws DropboxClientException
-     *
-     * @return void
-     */
-    public function open()
-    {
-        if (!$this->isRemoteFile($this->path)) {
-            if (self::MODE_READ === $this->mode && !is_readable($this->path)) {
-                throw new DropboxClientException('Failed to create DropboxFile instance. Unable to read resource: ' . $this->path . '.');
-            }
-            if (self::MODE_WRITE === $this->mode && file_exists($this->path) && !is_writable($this->path)) {
-                throw new DropboxClientException('Failed to create DropboxFile instance. Unable to write resource: ' . $this->path . '.');
-            }
-        }
-
-        $this->stream = \GuzzleHttp\Psr7\stream_for(fopen($this->path, $this->mode));
-
-        if (!$this->stream) {
-            throw new DropboxClientException('Failed to create DropboxFile instance. Unable to open resource: ' . $this->path . '.');
-        }
-    }
-
-    /**
-     * Get the Open File Stream
-     *
-     * @return \GuzzleHttp\Psr7\Stream
-     */
-    public function getStream()
-    {
-        if (!$this->stream) {
-            $this->open();
-        }
-        return $this->stream;
-    }
-
-    /**
-     * Close the file stream
-     */
-    public function close()
-    {
-        if ($this->stream) {
-            $this->stream->close();
-        }
     }
 
     /**
@@ -162,6 +181,102 @@ class DropboxFile
     }
 
     /**
+     * Get the Open File Stream
+     *
+     * @return \GuzzleHttp\Psr7\Stream
+     */
+    public function getStream()
+    {
+        if (!$this->stream) {
+            $this->open();
+        }
+        return $this->stream;
+    }
+
+    /**
+     * Manually set the stream for this DropboxFile instance
+     *
+     * @param $stream
+     */
+    public function setStream($stream)
+    {
+        $this->isStream = true;
+        $this->stream = $stream;
+    }
+
+    /**
+     * Opens the File Stream
+     *
+     * @throws DropboxClientException
+     *
+     * @return void
+     */
+    public function open()
+    {
+        // File was created from a stream so don't open it again
+        if ($this->isCreatedFromStream()) {
+            return;
+        }
+
+        // File is not a remote file
+        if (!$this->isRemoteFile($this->path)) {
+            // File is not Readable
+            if ($this->isNotReadable()) {
+                throw new DropboxClientException('Failed to create DropboxFile instance. Unable to read resource: ' . $this->path . '.');
+            }
+
+            // File is not Writable
+            if ($this->isNotWritable()) {
+                throw new DropboxClientException('Failed to create DropboxFile instance. Unable to write resource: ' . $this->path . '.');
+            }
+        }
+
+        // Create a stream
+        $this->stream = \GuzzleHttp\Psr7\stream_for(fopen($this->path, $this->mode));
+
+        // Unable to create stream
+        if (!$this->stream) {
+            throw new DropboxClientException('Failed to create DropboxFile instance. Unable to open resource: ' . $this->path . '.');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isCreatedFromStream()
+    {
+        return $this->stream && $this->isStream === true;
+    }
+
+    /**
+     * Returns true if the path to the file is remote
+     *
+     * @param string $pathToFile
+     *
+     * @return boolean
+     */
+    protected function isRemoteFile($pathToFile)
+    {
+        return preg_match('/^(https?|ftp):\/\/.*/', $pathToFile) === 1;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isNotReadable()
+    {
+        return self::MODE_READ === $this->mode && !is_readable($this->path);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isNotWritable()
+    {
+        return self::MODE_WRITE === $this->mode && file_exists($this->path) && !is_writable($this->path);
+    }
+
+    /**
      * Get the name of the file
      *
      * @return string
@@ -179,6 +294,11 @@ class DropboxFile
     public function getFilePath()
     {
         return $this->path;
+    }
+
+    public function getStreamOrFilePath()
+    {
+        return $this->isCreatedFromStream() ? $this->getStream() : $this->getFilePath();
     }
 
     /**
@@ -209,17 +329,5 @@ class DropboxFile
     public function getMimetype()
     {
         return \GuzzleHttp\Psr7\mimetype_from_filename($this->path) ?: 'text/plain';
-    }
-
-    /**
-     * Returns true if the path to the file is remote
-     *
-     * @param string $pathToFile
-     *
-     * @return boolean
-     */
-    protected function isRemoteFile($pathToFile)
-    {
-        return preg_match('/^(https?|ftp):\/\/.*/', $pathToFile) === 1;
     }
 }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxRequest.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Kunnu\Dropbox;
 
 use Kunnu\Dropbox\Http\RequestBodyStream;
@@ -82,7 +83,7 @@ class DropboxRequest
      *
      * @param string $method       HTTP Method of the Request
      * @param string $endpoint     API endpoint of the Request
-     * @param string $accessToken Access Token for the Request
+     * @param string $accessToken  Access Token for the Request
      * @param string $endpointType Endpoint type ['api'|'content']
      * @param mixed  $params       Request Params
      * @param array  $headers      Headers to send along with the Request
@@ -111,76 +112,6 @@ class DropboxRequest
         return $this->method;
     }
 
-     /**
-     * Get the Request Params
-     *
-     * @return array
-     */
-    public function getParams()
-    {
-        return $this->params;
-    }
-
-    /**
-     * Get Access Token for the Request
-     *
-     * @return string
-     */
-    public function getAccessToken()
-    {
-        return $this->accessToken;
-    }
-
-    /**
-     * Get the Endpoint of the Request
-     *
-     * @return string
-     */
-    public function getEndpoint()
-    {
-        return $this->endpoint;
-    }
-
-    /**
-     * Get the Endpoint Type of the Request
-     *
-     * @return string
-     */
-    public function getEndpointType()
-    {
-        return $this->endpointType;
-    }
-
-    /**
-     * Get the Content Type of the Request
-     *
-     * @return string
-     */
-    public function getContentType()
-    {
-        return $this->contentType;
-    }
-
-    /**
-     * Get Request Headers
-     *
-     * @return array
-     */
-    public function getHeaders()
-    {
-        return $this->headers;
-    }
-
-    /**
-     * Get the File to be sent with the Request
-     *
-     * @return \Kunnu\Dropbox\DropboxFile
-     */
-    public function getFile()
-    {
-        return $this->file;
-    }
-
     /**
      * Set the Request Method
      *
@@ -195,23 +126,15 @@ class DropboxRequest
         return $this;
     }
 
-     /**
-     * Set the Request Params
+    /**
+     * Get Access Token for the Request
      *
-     * @param array
-     *
-     * @return \Kunnu\Dropbox\DropboxRequest
+     * @return string
      */
-     public function setParams(array $params = [])
-     {
-         //Process Params
-        $params = $this->processParams($params);
-
-        //Set the params
-        $this->params = $params;
-
-         return $this;
-     }
+    public function getAccessToken()
+    {
+        return $this->accessToken;
+    }
 
     /**
      * Set Access Token for the Request
@@ -225,6 +148,16 @@ class DropboxRequest
         $this->accessToken = $accessToken;
 
         return $this;
+    }
+
+    /**
+     * Get the Endpoint of the Request
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint;
     }
 
     /**
@@ -242,6 +175,16 @@ class DropboxRequest
     }
 
     /**
+     * Get the Endpoint Type of the Request
+     *
+     * @return string
+     */
+    public function getEndpointType()
+    {
+        return $this->endpointType;
+    }
+
+    /**
      * Set the Endpoint Type of the Request
      *
      * @param string
@@ -255,19 +198,14 @@ class DropboxRequest
         return $this;
     }
 
-
     /**
-     * Set Request Headers
+     * Get the Content Type of the Request
      *
-     * @param array
-     *
-     * @return \Kunnu\Dropbox\DropboxRequest
+     * @return string
      */
-    public function setHeaders(array $headers)
+    public function getContentType()
     {
-        $this->headers = array_merge($this->headers, $headers);
-
-        return $this;
+        return $this->contentType;
     }
 
     /**
@@ -285,15 +223,25 @@ class DropboxRequest
     }
 
     /**
-     * Set the File to be sent with the Request
+     * Get Request Headers
      *
-     * @param \Kunnu\Dropbox\DropboxFile
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Set Request Headers
+     *
+     * @param array
      *
      * @return \Kunnu\Dropbox\DropboxRequest
      */
-    public function setFile(DropboxFile $file)
+    public function setHeaders(array $headers)
     {
-        $this->file = $file;
+        $this->headers = array_merge($this->headers, $headers);
 
         return $this;
     }
@@ -309,6 +257,35 @@ class DropboxRequest
     }
 
     /**
+     * Get the Request Params
+     *
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * Set the Request Params
+     *
+     * @param array
+     *
+     * @return \Kunnu\Dropbox\DropboxRequest
+     */
+    public function setParams(array $params = [])
+    {
+
+        //Process Params
+        $params = $this->processParams($params);
+
+        //Set the params
+        $this->params = $params;
+
+        return $this;
+    }
+
+    /**
      * Get Stream Request Body
      *
      * @return \Kunnu\Dropbox\Http\RequestBodyStream
@@ -316,6 +293,30 @@ class DropboxRequest
     public function getStreamBody()
     {
         return new RequestBodyStream($this->getFile());
+    }
+
+    /**
+     * Get the File to be sent with the Request
+     *
+     * @return \Kunnu\Dropbox\DropboxFile
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Set the File to be sent with the Request
+     *
+     * @param \Kunnu\Dropbox\DropboxFile
+     *
+     * @return \Kunnu\Dropbox\DropboxRequest
+     */
+    public function setFile(DropboxFile $file)
+    {
+        $this->file = $file;
+
+        return $this;
     }
 
     /**
@@ -341,7 +342,7 @@ class DropboxRequest
     /**
      * Process Params for the File parameter
      *
-     * @param  array  $params Request Params
+     * @param  array $params Request Params
      *
      * @return array
      */

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxResponse.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxResponse.php
@@ -31,7 +31,7 @@ class DropboxResponse
      *
      * @var array
      */
-    protected $decodedBody;
+    protected $decodedBody = [];
 
     /**
      * The original request that returned this response
@@ -103,14 +103,15 @@ class DropboxResponse
     /**
      * Get the Decoded Body
      *
-     * @return string
+     * @return array
      */
     public function getDecodedBody()
     {
-        if ($this->decodedBody === null) {
+        if (empty($this->decodedBody) || $this->decodedBody === null) {
             //Decode the Response Body
             $this->decodeBody();
         }
+
         return $this->decodedBody;
     }
 
@@ -156,9 +157,7 @@ class DropboxResponse
         $body = $this->getBody();
 
         if (isset($this->headers['Content-Type']) && in_array('application/json', $this->headers['Content-Type'])) {
-            $this->decodedBody = json_decode((string)$body, true);
-        } else {
-            $this->decodedBody = $this->body;
+            $this->decodedBody = (array) json_decode((string) $body, true);
         }
 
         // If the response needs to be validated
@@ -172,6 +171,8 @@ class DropboxResponse
      * Validate Response
      *
      * @return void
+     *
+     * @throws \Kunnu\Dropbox\Exceptions\DropboxClientException
      */
     protected function validateResponse()
     {

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxResponseToFile.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/DropboxResponseToFile.php
@@ -31,4 +31,9 @@ class DropboxResponseToFile extends DropboxResponse
     {
         return $this->file->getFilePath();
     }
+
+    public function getSteamOrFilePath()
+    {
+        return $this->file->getStreamOrFilePath();
+    }
 }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/Clients/DropboxGuzzleHttpClient.php
@@ -1,29 +1,30 @@
 <?php
+
 namespace Kunnu\Dropbox\Http\Clients;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Exception\RingException;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Exception\RequestException;
 use Kunnu\Dropbox\Http\DropboxRawResponse;
+use GuzzleHttp\Exception\BadResponseException;
 use Kunnu\Dropbox\Exceptions\DropboxClientException;
 
 /**
- * DropboxGuzzleHttpClient
+ * DropboxGuzzleHttpClient.
  */
 class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
 {
     /**
-     * GuzzleHttp client
+     * GuzzleHttp client.
      *
      * @var \GuzzleHttp\Client
      */
     protected $client;
 
     /**
-     * Create a new DropboxGuzzleHttpClient instance
+     * Create a new DropboxGuzzleHttpClient instance.
      *
      * @param Client $client GuzzleHttp Client
      */
@@ -34,7 +35,7 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
     }
 
     /**
-     * Send request to the server and fetch the raw response
+     * Send request to the server and fetch the raw response.
      *
      * @param  string $url     URL/Endpoint to send the request to
      * @param  string $method  Request Method
@@ -54,10 +55,12 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
         try {
             //Send the Request
             $rawResponse = $this->client->send($request, $options);
+        } catch (BadResponseException $e) {
+            throw new DropboxClientException($e->getResponse()->getBody(), $e->getCode(), $e);
         } catch (RequestException $e) {
             $rawResponse = $e->getResponse();
 
-            if ($e->getPrevious() instanceof RingException || !$rawResponse instanceof ResponseInterface) {
+            if (! $rawResponse instanceof ResponseInterface) {
                 throw new DropboxClientException($e->getMessage(), $e->getCode());
             }
         }
@@ -83,7 +86,7 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
     }
 
     /**
-     * Get the Response Body
+     * Get the Response Body.
      *
      * @param string|\Psr\Http\Message\ResponseInterface $response Response object
      *
@@ -103,6 +106,6 @@ class DropboxGuzzleHttpClient implements DropboxHttpClientInterface
             $body = $body->getContents();
         }
 
-        return $body;
+        return (string) $body;
     }
 }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/Clients/DropboxHttpClientFactory.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/Clients/DropboxHttpClientFactory.php
@@ -12,7 +12,7 @@ class DropboxHttpClientFactory
     /**
      * Make HTTP Client
      *
-     * @param  DropboxHttpClientInterface|GuzzleHttp\Client|null $handler
+     * @param  \Kunnu\Dropbox\Http\Clients\DropboxHttpClientInterface|\GuzzleHttp\Client|null $handler
      *
      * @return \Kunnu\Dropbox\Http\Clients\DropboxHttpClientInterface
      */
@@ -23,7 +23,7 @@ class DropboxHttpClientFactory
             return new DropboxGuzzleHttpClient();
         }
 
-        //Custom Implemenation, maybe.
+        //Custom Implementation, maybe.
         if ($handler instanceof DropboxHttpClientInterface) {
             return $handler;
         }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/Clients/DropboxHttpClientInterface.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/Clients/DropboxHttpClientInterface.php
@@ -11,7 +11,7 @@ interface DropboxHttpClientInterface
      *
      * @param  string $url     URL/Endpoint to send the request to
      * @param  string $method  Request Method
-     * @param  string|resource|StreamInterface $body Request Body
+     * @param  string|resource|\Psr\Http\Message\StreamInterface|null $body Request Body
      * @param  array  $headers Request Headers
      * @param  array  $options Additional Options
      *

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/RequestBodyJsonEncoded.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/RequestBodyJsonEncoded.php
@@ -27,7 +27,7 @@ class RequestBodyJsonEncoded implements RequestBodyInterface
     /**
      * Get the Body of the Request
      *
-     * @return string
+     * @return string|null
      */
     public function getBody()
     {

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/RequestBodyStream.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Http/RequestBodyStream.php
@@ -29,7 +29,7 @@ class RequestBodyStream implements RequestBodyInterface
     /**
      * Get the Body of the Request
      *
-     * @return resource
+     * @return string
      */
     public function getBody()
     {

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/Account.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/Account.php
@@ -90,7 +90,7 @@ class Account extends BaseModel
         parent::__construct($data);
 
         $this->account_id = $this->getDataProperty('account_id');
-        $this->name = $this->getDataProperty('name');
+        $this->name = (array) $this->getDataProperty('name');
         $this->email = $this->getDataProperty('email');
         $this->email_verified = $this->getDataProperty('email_verified');
         $this->disabled = $this->getDataProperty('disabled');

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/CopyReference.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/CopyReference.php
@@ -55,7 +55,7 @@ class CopyReference extends BaseModel
     /**
      * Get the expiration date of the copy reference
      *
-     * @var DateTime
+     * @return DateTime
      */
     public function getExpirationDate()
     {

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/FileMetadata.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/FileMetadata.php
@@ -12,6 +12,13 @@ class FileMetadata extends BaseModel
     protected $id;
 
     /**
+     * Object type
+     *
+     * @var string
+     */
+    protected $tag;
+
+    /**
      * The last component of the path (including extension).
      *
      * @var string
@@ -66,14 +73,14 @@ class FileMetadata extends BaseModel
      * For files, this is the modification time set by the
      * desktop client when the file was added to Dropbox.
      *
-     * @var DateTime
+     * @var string
      */
     protected $client_modified;
 
     /**
      * The last time the file was modified on Dropbox.
      *
-     * @var DateTime
+     * @var string
      */
     protected $server_modified;
 
@@ -100,6 +107,7 @@ class FileMetadata extends BaseModel
     {
         parent::__construct($data);
         $this->id = $this->getDataProperty('id');
+        $this->tag = $this->getDataProperty('.tag');
         $this->rev = $this->getDataProperty('rev');
         $this->name = $this->getDataProperty('name');
         $this->size = $this->getDataProperty('size');
@@ -130,6 +138,16 @@ class FileMetadata extends BaseModel
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * Get the '.tag' property of the file model.
+     *
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->tag;
     }
 
     /**
@@ -205,7 +223,7 @@ class FileMetadata extends BaseModel
     /**
      * Get the 'client_modified' property of the file model.
      *
-     * @return DateTime
+     * @return string
      */
     public function getClientModified()
     {
@@ -215,7 +233,7 @@ class FileMetadata extends BaseModel
     /**
      * Get the 'server_modified' property of the file model.
      *
-     * @return DateTime
+     * @return string
      */
     public function getServerModified()
     {

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/FolderMetadata.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/FolderMetadata.php
@@ -12,6 +12,13 @@ class FolderMetadata extends BaseModel
     protected $id;
 
     /**
+     * Object type
+     *
+     * @var string
+     */
+    protected $tag;
+
+    /**
      * The last component of the path (including extension).
      * This never contains a slash.
      *
@@ -51,6 +58,7 @@ class FolderMetadata extends BaseModel
     {
         parent::__construct($data);
         $this->id = $this->getDataProperty('id');
+        $this->tag = $this->getDataProperty('.tag');
         $this->name = $this->getDataProperty('name');
         $this->path_lower = $this->getDataProperty('path_lower');
         $this->path_display = $this->getDataProperty('path_display');
@@ -70,6 +78,16 @@ class FolderMetadata extends BaseModel
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * Get the '.tag' property of the folder model.
+     *
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->tag;
     }
 
     /**

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/MediaMetadata.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/MediaMetadata.php
@@ -36,8 +36,8 @@ class MediaMetadata extends BaseModel
     public function __construct(array $data)
     {
         parent::__construct($data);
-        $this->location = $this->getDataProperty('location');
-        $this->dimensions = $this->getDataProperty('dimensions');
+        $this->location = (array) $this->getDataProperty('location');
+        $this->dimensions = (array) $this->getDataProperty('dimensions');
 
         $time_taken = $this->getDataProperty('time_taken');
         if ($time_taken) {

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/MetadataCollection.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/MetadataCollection.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kunnu\Dropbox\Models;
 
-class MetadataCollection
+class MetadataCollection extends BaseModel
 {
 
     /**
@@ -60,7 +60,8 @@ class MetadataCollection
      */
     public function __construct(array $data)
     {
-        $this->data = $data;
+        parent::__construct($data);
+
         $this->cursor = isset($data[$this->getCollectionCursorKey()]) ? $data[$this->getCollectionCursorKey()] : '';
         $this->hasMoreItems = isset($data[$this->getCollectionHasMoreItemsKey()]) && $data[$this->getCollectionHasMoreItemsKey()] ? true : false;
 
@@ -96,16 +97,6 @@ class MetadataCollection
     public function getCollectionCursorKey()
     {
         return static::COLLECTION_CURSOR_KEY;
-    }
-
-    /**
-     * Get the Collection data
-     *
-     * @return array
-     */
-    public function getData()
-    {
-        return $this->data;
     }
 
     /**

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/ModelFactory.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/ModelFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Kunnu\Dropbox\Models;
 
 class ModelFactory
@@ -7,47 +8,117 @@ class ModelFactory
     /**
      * Make a Model Factory
      *
-     * @param  array  $data Model Data
+     * @param  array $data Model Data
      *
      * @return \Kunnu\Dropbox\Models\ModelInterface
      */
     public static function make(array $data = array())
     {
-        if (isset($data['.tag']) && isset($data['id'])) {
+        if (static::isFileOrFolder($data)) {
             $tag = $data['.tag'];
 
             //File
-            if ($tag === 'file') {
+            if (static::isFile($tag)) {
                 return new FileMetadata($data);
             }
 
             //Folder
-            if ($tag === 'folder') {
+            if (static::isFolder($tag)) {
                 return new FolderMetadata($data);
             }
         }
 
         //Temporary Link
-        if (isset($data['metadata']) && isset($data['link'])) {
+        if (static::isTemporaryLink($data)) {
             return new TemporaryLink($data);
         }
 
         //List
-        if (isset($data['entries'])) {
+        if (static::isList($data)) {
             return new MetadataCollection($data);
         }
 
         //Search Results
-        if (isset($data['matches'])) {
+        if (static::isSearchResult($data)) {
             return new SearchResults($data);
         }
 
         //Deleted File/Folder
-        if (!isset($data['.tag']) || !isset($data['id'])) {
+        if (static::isDeletedFileOrFolder($data)) {
             return new DeletedMetadata($data);
         }
 
         //Base Model
         return new BaseModel($data);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected static function isFileOrFolder(array $data)
+    {
+        return isset($data['.tag']) && isset($data['id']);
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return bool
+     */
+    protected static function isFile($tag)
+    {
+        return $tag === 'file';
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return bool
+     */
+    protected static function isFolder($tag)
+    {
+        return $tag === 'folder';
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected static function isTemporaryLink(array $data)
+    {
+        return isset($data['metadata']) && isset($data['link']);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected static function isList(array $data)
+    {
+        return isset($data['entries']);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected static function isSearchResult(array $data)
+    {
+        return isset($data['matches']);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected static function isDeletedFileOrFolder(array $data)
+    {
+        return !isset($data['.tag']) || !isset($data['id']);
     }
 }

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/TemporaryLink.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Models/TemporaryLink.php
@@ -1,8 +1,6 @@
 <?php
 namespace Kunnu\Dropbox\Models;
 
-use DateTime;
-
 class TemporaryLink extends BaseModel
 {
 

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Security/RandomStringGeneratorFactory.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Security/RandomStringGeneratorFactory.php
@@ -33,14 +33,14 @@ class RandomStringGeneratorFactory
             return $generator;
         }
 
-        //Mcrypt
+        // Mcrypt
         if ('mcrypt' === $generator) {
-            return new McryptPseudoRandomStringGenerator();
+            return new McryptRandomStringGenerator();
         }
 
         //OpenSSL
         if ('openssl' === $generator) {
-            return new OpenSslPseudoRandomStringGenerator();
+            return new OpenSslRandomStringGenerator();
         }
 
         //Invalid Argument

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Store/PersistentDataStoreFactory.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Store/PersistentDataStoreFactory.php
@@ -2,8 +2,6 @@
 namespace Kunnu\Dropbox\Store;
 
 use InvalidArgumentException;
-use Kunnu\Dropbox\Exceptions\DropboxClientException;
-use Kunnu\Dropbox\Store\PersistentDataStoreInterface;
 
 /**
  * Thanks to Facebook

--- a/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Store/SessionPersistentDataStore.php
+++ b/vendor/kunalvarma05/dropbox-php-sdk/src/Dropbox/Store/SessionPersistentDataStore.php
@@ -26,7 +26,7 @@ class SessionPersistentDataStore implements PersistentDataStoreInterface
      *
      * @param  string $key Data Key
      *
-     * @return string
+     * @return string|null
      */
     public function get($key)
     {


### PR DESCRIPTION
Downloading big files is not working because the file is saved as a
whole into memory.

This commit will write the file directly into php://output without
being saved into memory.

Dropbox-PHP-SDK is updated to a fork based on 0.2.1. The PR to upstream
has been made: https://github.com/kunalvarma05/dropbox-php-sdk/pull/122