### PR TITLE
Migrate from access token to long living refresh token

### DIFF
--- a/Classes/Driver/DropboxDriver.php
+++ b/Classes/Driver/DropboxDriver.php
@@ -13,6 +13,7 @@ namespace StefanFroemken\Dropbox\Driver;
 
 use Spatie\Dropbox\Client;
 use Spatie\Dropbox\Exceptions\BadRequest;
+use StefanFroemken\Dropbox\Service\AutoRefreshingDropboxTokenService;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
@@ -55,8 +56,9 @@ class DropboxDriver extends AbstractDriver
         $this->cache = GeneralUtility::makeInstance(CacheManager::class)
             ->getCache('dropbox');
 
-        if (!empty($this->configuration['accessToken'])) {
-            $this->dropboxClient = new Client((string)$this->configuration['accessToken']);
+        if (!empty($this->configuration['refreshToken']) && !empty($this->configuration['appKey'])) {
+            $tokenService = GeneralUtility::makeInstance(AutoRefreshingDropboxTokenService::class, $this->configuration['refreshToken'], $this->configuration['appKey']);
+            $this->dropboxClient = new Client($tokenService->getToken());
         } else {
             $this->dropboxClient = null;
         }

--- a/Classes/Form/Element/AccessTokenElement.php
+++ b/Classes/Form/Element/AccessTokenElement.php
@@ -53,6 +53,7 @@ class AccessTokenElement extends AbstractFormElement
 
         $parameterArray = $this->data['parameterArray'];
         $itemName = $parameterArray['itemFormElName'];
+        $appKeyFieldName = str_replace($this->data['flexFormFieldName'], $parameterArray['fieldConf']['config']['fieldControl']['accessToken']['appKeyFieldName'], $parameterArray['itemFormElName']);
 
         $fieldWizardResult = $this->renderFieldWizard();
         $fieldWizardHtml = $fieldWizardResult['html'];
@@ -74,6 +75,7 @@ class AccessTokenElement extends AbstractFormElement
         $resultArray['linkAttributes'] = [
             'class' => $fieldId,
             'data-itemname' => $itemName,
+            'data-appkeyfieldname' => $appKeyFieldName,
             'onClick' => 'return false;'
         ];
         $resultArray['html'] = implode(LF, $mainFieldHtml);

--- a/Classes/Service/AutoRefreshingDropboxTokenService.php
+++ b/Classes/Service/AutoRefreshingDropboxTokenService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package stefanfroemken/dropbox.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace StefanFroemken\Dropbox\Service;
+
+use GuzzleHttp\Exception\ClientException;
+use Spatie\Dropbox\TokenProvider;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class AutoRefreshingDropboxTokenService implements TokenProvider {
+
+    /**
+     * @var string
+     */
+    protected string $refreshToken;
+
+    /**
+     * @var string
+     */
+    protected string $appKey;
+
+    /**
+     * @param string $refreshToken
+     * @param string $appKey
+     */
+    public function __construct(string $refreshToken, string $appKey){
+        $this->refreshToken = $refreshToken;
+        $this->appKey = $appKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToken() :string
+    {
+        try {
+            $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+            $response = $requestFactory->request('https://api.dropbox.com/oauth2/token', 'POST', [
+                'form_params' => [
+                    'grant_type' => 'refresh_token',
+                    'refresh_token' => $this->refreshToken,
+                    'client_id' => $this->appKey
+                ]
+            ]);
+            $responseArray = json_decode($response->getBody()->getContents(), true);
+            $accessToken = $responseArray['access_token'];
+        } catch (ClientException $clientException) {
+            $accessToken = '';
+        }
+        return $accessToken;
+    }
+}

--- a/Configuration/FlexForms/Dropbox.xml
+++ b/Configuration/FlexForms/Dropbox.xml
@@ -6,9 +6,19 @@
 	<ROOT>
 		<type>array</type>
 		<el>
-			<accessToken>
+			<appKey>
 				<TCEforms>
-					<label>LLL:EXT:dropbox/Resources/Private/Language/FlexForm.xlf:accessToken</label>
+					<label>LLL:EXT:dropbox/Resources/Private/Language/FlexForm.xlf:appKey</label>
+					<config>
+						<type>input</type>
+						<eval>trim</eval>
+						<size>30</size>
+					</config>
+				</TCEforms>
+			</appKey>
+			<refreshToken>
+				<TCEforms>
+					<label>LLL:EXT:dropbox/Resources/Private/Language/FlexForm.xlf:refreshToken</label>
 					<config>
 						<type>input</type>
 						<eval>trim</eval>
@@ -16,11 +26,12 @@
 						<fieldControl>
 							<accessToken>
 								<renderType>accessToken</renderType>
+								<appKeyFieldName>appKey</appKeyFieldName>
 							</accessToken>
 						</fieldControl>
 					</config>
 				</TCEforms>
-			</accessToken>
+			</refreshToken>
 			<accessType>
 				<TCEforms>
 					<label>LLL:EXT:dropbox/Resources/Private/Language/FlexForm.xlf:accessType</label>

--- a/Resources/Private/Language/FlexForm.xlf
+++ b/Resources/Private/Language/FlexForm.xlf
@@ -3,8 +3,11 @@
 	<file source-language="en" datatype="plaintext" original="messages" date="2013-07-04T09:16:00Z" product-name="dropbox">
 		<header/>
 		<body>
-			<trans-unit id="accessToken">
-				<source>Insert the access_token of Dropbox or create one with help of the wizard.</source>
+			<trans-unit id="appKey">
+				<source>Dropbox app_key.</source>
+			</trans-unit>
+			<trans-unit id="refreshToken">
+				<source>Create a Dropbox refresh_token with help of the wizard.</source>
 			</trans-unit>
 			<trans-unit id="accessType">
 				<source>Access Type</source>

--- a/Resources/Private/Language/de.FlexForm.xlf
+++ b/Resources/Private/Language/de.FlexForm.xlf
@@ -3,9 +3,13 @@
 	<file source-language="en" datatype="plaintext" original="messages" date="2013-07-04T09:16:00Z" product-name="dropbox">
 		<header/>
 		<body>
-			<trans-unit id="accessToken">
-				<source>Insert the access_token of Dropbox or create one with help of the wizard.</source>
-				<target>Tragen Sie hier den access_token von Dropbox ein oder erstellen Sie einen über den Wizard.</target>
+			<trans-unit id="appKey">
+				<source>Dropbox app_key.</source>
+				<target>Dropbox app_key.</target>
+			</trans-unit>
+			<trans-unit id="refreshToken">
+				<source>Create a Dropbox refresh_token with help of the wizard.</source>
+				<target>Erstellen Sie einen Dropbox refresh_token über den Wizard.</target>
 			</trans-unit>
 			<trans-unit id="accessType.appFolder">
 				<source>App Folder</source>


### PR DESCRIPTION
Dropbox changed it's API, access tokens expire after a while. Long living refresh tokens should be used instead.

Resolve: #23